### PR TITLE
Make document upload section expandable

### DIFF
--- a/src/components/DocumentManager.css
+++ b/src/components/DocumentManager.css
@@ -6,9 +6,9 @@
   color: #0f172a;
   border-radius: 18px;
   padding: 18px 20px;
-  display: grid;
-  grid-template-rows: auto 1fr;
-  gap: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
   box-shadow: 0 20px 46px rgba(15, 23, 42, 0.12);
   border: 1px solid rgba(15, 23, 42, 0.06);
   position: sticky;
@@ -19,26 +19,49 @@
 
 .document-manager__header {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   justify-content: space-between;
   gap: 12px;
 }
 
-.document-manager__header > div {
+.document-manager__toggle {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
   flex: 1;
+  border: none;
+  background: transparent;
+  padding: 0;
+  text-align: left;
+  cursor: pointer;
+  color: inherit;
 }
 
-.document-manager__header h2 {
+.document-manager__summary h2 {
   margin: 0;
   font-size: 1.1rem;
   letter-spacing: 0.01em;
 }
 
-.document-manager__header p {
+.document-manager__summary p {
   margin: 6px 0 0;
   color: #64748b;
   font-size: 0.85rem;
   line-height: 1.4;
+}
+
+.document-manager__chevron {
+  margin-top: 6px;
+  width: 10px;
+  height: 10px;
+  border-right: 2px solid currentColor;
+  border-bottom: 2px solid currentColor;
+  transform: rotate(45deg);
+  transition: transform 0.2s ease;
+}
+
+.document-manager__toggle[aria-expanded='false'] .document-manager__chevron {
+  transform: rotate(-135deg);
 }
 
 .document-manager__upload {
@@ -67,6 +90,17 @@
   margin: 0;
   color: #f87171;
   font-weight: 600;
+}
+
+.document-manager__content {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  min-height: 0;
+}
+
+[hidden].document-manager__content {
+  display: none;
 }
 
 .document-manager__list {
@@ -161,5 +195,9 @@
     width: 100%;
     max-height: none;
     backdrop-filter: none;
+  }
+
+  .document-manager__header {
+    align-items: flex-start;
   }
 }

--- a/src/components/DocumentManager.tsx
+++ b/src/components/DocumentManager.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, useRef, useState } from 'react';
+import { ChangeEvent, useId, useRef, useState } from 'react';
 import type { DocumentRecord } from '../types';
 import './DocumentManager.css';
 
@@ -12,6 +12,8 @@ interface DocumentManagerProps {
 export function DocumentManager({ documents, onUpload, onDownload, isUploading }: DocumentManagerProps) {
   const inputRef = useRef<HTMLInputElement | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [isExpanded, setIsExpanded] = useState(true);
+  const contentId = useId();
   const summary = documents.length
     ? `${documents.length} uploaded file${documents.length === 1 ? '' : 's'} ready for reference.`
     : 'Upload supporting material for the ingestion agent.';
@@ -32,12 +34,21 @@ export function DocumentManager({ documents, onUpload, onDownload, isUploading }
   };
 
   return (
-    <section className="document-manager">
+    <section className={`document-manager ${isExpanded ? 'document-manager--expanded' : 'document-manager--collapsed'}`}>
       <header className="document-manager__header">
-        <div>
-          <h2>Evidence</h2>
-          <p>{summary}</p>
-        </div>
+        <button
+          type="button"
+          className="document-manager__toggle"
+          aria-expanded={isExpanded}
+          aria-controls={contentId}
+          onClick={() => setIsExpanded((value) => !value)}
+        >
+          <span className="document-manager__chevron" aria-hidden />
+          <div className="document-manager__summary">
+            <h2>Evidence</h2>
+            <p>{summary}</p>
+          </div>
+        </button>
         <button
           type="button"
           className="document-manager__upload"
@@ -55,33 +66,35 @@ export function DocumentManager({ documents, onUpload, onDownload, isUploading }
         />
       </header>
 
-      {error && <p className="document-manager__error">{error}</p>}
+      <div id={contentId} className="document-manager__content" hidden={!isExpanded}>
+        {error && <p className="document-manager__error">{error}</p>}
 
-      <ul className="document-manager__list">
-        {documents.length === 0 ? (
-          <li className="document-manager__empty">No documents uploaded yet.</li>
-        ) : (
-          documents.map((doc) => (
-            <li key={doc.id} className="document-manager__item">
-              <div className="document-manager__meta">
-                <h3>{doc.originalName}</h3>
-                <p>
-                  Uploaded {new Date(doc.uploadedAt).toLocaleString()} — {(doc.size / 1024).toFixed(1)} KB
-                </p>
-                <p className={`document-manager__status document-manager__status--${doc.status}`}>
-                  {doc.status === 'processing' ? 'Processing' : doc.status === 'processed' ? 'Processed' : 'Failed'}
-                </p>
-                {doc.notes && <p className="document-manager__notes">{doc.notes}</p>}
-              </div>
-              <div className="document-manager__actions">
-                <button type="button" onClick={() => void onDownload(doc)} disabled={doc.status !== 'processed'}>
-                  Download
-                </button>
-              </div>
-            </li>
-          ))
-        )}
-      </ul>
+        <ul className="document-manager__list">
+          {documents.length === 0 ? (
+            <li className="document-manager__empty">No documents uploaded yet.</li>
+          ) : (
+            documents.map((doc) => (
+              <li key={doc.id} className="document-manager__item">
+                <div className="document-manager__meta">
+                  <h3>{doc.originalName}</h3>
+                  <p>
+                    Uploaded {new Date(doc.uploadedAt).toLocaleString()} — {(doc.size / 1024).toFixed(1)} KB
+                  </p>
+                  <p className={`document-manager__status document-manager__status--${doc.status}`}>
+                    {doc.status === 'processing' ? 'Processing' : doc.status === 'processed' ? 'Processed' : 'Failed'}
+                  </p>
+                  {doc.notes && <p className="document-manager__notes">{doc.notes}</p>}
+                </div>
+                <div className="document-manager__actions">
+                  <button type="button" onClick={() => void onDownload(doc)} disabled={doc.status !== 'processed'}>
+                    Download
+                  </button>
+                </div>
+              </li>
+            ))
+          )}
+        </ul>
+      </div>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- add an expand/collapse toggle to the document manager header so the evidence list can be hidden or shown
- rework the document manager layout and styles to support the collapsible content area and chevron indicator

## Testing
- npm install *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2freact)*

------
https://chatgpt.com/codex/tasks/task_e_68e10bfd981c832eb416f589bbb9f631